### PR TITLE
Starting library of Sandstone patterns

### DIFF
--- a/css/styleguide-lite.css
+++ b/css/styleguide-lite.css
@@ -7,18 +7,25 @@
     width: 100%;
 }
 
-h1 {
-    margin-bottom: 60px;
+.sg-site-title {
+    margin-bottom: 40px;
 }
 
-.nav-left {
+.sg-page-title {
+    font-size: 2.5rem;
+    padding-bottom: .25em;
+    margin-bottom: 40px;
+    border-bottom: 1px solid rgba(0, 0, 0, .2);
+}
+
+.sg-nav-main {
     display: inline-block;
-    width: 400px;
+    width: 25%;
     max-width: 350px;
     vertical-align: top;
 }
 
-.nav-left h2 {
+.sg-nav-main h2 {
     position: absolute!important;
     height: 1px;
     width: 1px;
@@ -29,25 +36,42 @@ h1 {
     border: 0;
 }
 
-.nav-left li {
+.sg-nav-main li {
     display: block;
     padding: 5px 0
 }
 
-#main-content {
+.sg-main-content {
     display: inline-block;
     width: 70%;
     vertical-align: top;
 }
 
-#main-content:focus {
+.sg-main-content:focus {
     outline: none;
 }
 
-#main-content h3 {
-    margin-top: 40px;
-}
 
 .sample-container {
+    margin: 20px 0;
+}
+
+.code-sample {
     margin-bottom: 40px;
+}
+
+.code-sample h4 {
+    font-size: .75rem;
+    font-family: 'Open Sans', sans-serif;
+    letter-spacing: normal;
+    color: #999;
+}
+
+@media screen and (max-width: 440px) {
+    .sg-nav-main,
+    .sg-main-content {
+        display: block;
+        width: 100%;
+        margin-bottom: 1em;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -10,21 +10,21 @@
   <body>
     <div id="outer-wrapper">
       <div id="wrapper">
-        <h1>Styleguide Lite</h1>
-        <nav class="nav-left" role="navigation">
+        <h1 class="sg-site-title">Styleguide Lite</h1>
+
+        <nav class="sg-nav-main" role="navigation">
           <h2>Main Navigation</h2>
           <ul>
               <li><a href="/styleguide/index.html">Overview</a></li>
-              <li><a href="/styleguide/themes/index.html">Themes</a></li>
               <li><a href="/styleguide/grid/index.html">Grid</a></li>
+              <li><a href="/styleguide/headings/index.html">Headings</a></li>
+              <li><a href="/styleguide/tables-and-lists/index.html">Tables and Lists</a></li>
               <li><a href="/styleguide/buttons/index.html">Buttons</a></li>
               <li><a href="/styleguide/forms/index.html">Forms</a></li>
-              <li><a href="/styleguide/tables/index.html">Tables</a></li>
-              <li><a href="/styleguide/lists/index.html">Lists</a></li>
-              <li><a href="/styleguide/typefaces/index.html">Typefaces</a></li>
+              <li><a href="/styleguide/components/index.html">Components</a></li>
           </ul>
         </nav>
-        <main id="main-content" class="main-content" role="main" tabindex="-1"></main>
+        <main class="sg-main-content" role="main" tabindex="-1"></main>
       </div>
 
       <footer id="colophon">

--- a/js/styleguide-lite.js
+++ b/js/styleguide-lite.js
@@ -1,7 +1,7 @@
 $(function() {
     var location = window.location.pathname;
     var sectionsPath = 'styleguide/';
-    var $container = $('#main-content');
+    var $container = $('.sg-main-content');
     var menuBar = $('nav');
     var initialSegment = '';
 

--- a/styleguide/buttons/index.html
+++ b/styleguide/buttons/index.html
@@ -1,44 +1,42 @@
-<h2>Buttons</h2>
+<h2 class="sg-page-title">Buttons</h2>
 <p>Buttons come in three varieties: download buttons, standard buttons and user flow buttons.</p>
 
-<h3>Download buttons</h3>
-<section class="sample-container">
-  <button class="button-green">download</button>
+<section id="download">
+  <h3>Download buttons</h3>
+  <div class="sample-container">
+    <a href="#" class="button-green">download</a>
+  </div>
+
+  <div class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </div>
 </section>
 
-<section class="code-sample show">
-<h4>HTML</h4>
-<pre>
-<code class="language-markup"></code>
-</pre>
-</section>
-
+<section id="standard">
 <h3>Standard buttons</h3>
 
-<section class="sample-container">
-  <button class="button">default</button>
-  <button class="button hover">hover</button>
-  <button class="button active">active</button>
-  <button class="button insensitive">insensitive</button>
+  <div class="sample-container">
+    <button class="button">default</button>
+    <button class="button insensitive">insensitive</button>
+  </div>
+
+  <div class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </div>
 </section>
 
-<section class="code-sample show">
-<h4>HTML</h4>
+<section id="user-flow">
+  <h3>User flow buttons</h3>
 
-<pre>
-<code class="language-markup"></code>
-</pre>
-</section>
+  <div class="sample-container">
+    <button class="button">next</button>
+    <button class="button-negative">no</button>
+  </div>
 
-<h3>User flow buttons</h3>
-<section class="sample-container">
-  <button class="button">next</button>
-  <button class="button-negative">no</button>
-</section>
-
-<section class="code-sample show">
-<h4>HTML</h4>
-<pre>
-<code class="language-markup"></code>
-</pre>
+  <div class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </div>
 </section>

--- a/styleguide/components/index.html
+++ b/styleguide/components/index.html
@@ -1,0 +1,21 @@
+<h2 class="sg-page-title">Components</h2>
+
+<section id="billboard">
+  <h3>Billboard</h3>
+  <p>A “billboard” is a styled box used as an emphasized callout, a related
+    sidebar, or otherwise distinctive block of content. The actual contents
+    of a billboard vary; this is just a generic style for a special box.</p>
+
+  <div class="sample-container">
+    <aside class="billboard">
+      <h2>Look at me!</h2>
+      <p>I live in a box. I live on a one way street.</p>
+    </aside>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+

--- a/styleguide/forms/index.html
+++ b/styleguide/forms/index.html
@@ -1,1 +1,122 @@
-<h2>Feed me Malcolm, feed me!</h2>
+<h2 class="sg-page-title">Forms</h2>
+<p>Use meaningful markup like lists and paragrapgs to give forms a logical
+  structure. A form control should almost always be paired with a useful label.</p>
+
+<section id="text">
+  <h3>Text input</h3>
+
+  <div class="sample-container">
+    <label for="text">Text</label>
+    <input type="text" name="text" id="text">
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="text">
+  <h3>Input with placeholder</h3>
+  <p>Field placeholders should show an example of the expected input, such as
+    suggested search terms or a demonstration of a correctly formatted email address.
+    The <code>placeholder</code> attribute should <strong>not</strong> be used
+    as a substitute for a label.</p>
+
+  <div class="sample-container">
+    <label for="email">E-mail</label>
+    <input type="email" name="email" id="email" placeholder="you@example.com">
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="text">
+  <h3>Text area</h3>
+
+  <div class="sample-container">
+    <label for="textarea">Text area</label>
+    <textarea name="textarea" id="textarea" row="4" cols="60"></textarea>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="radio">
+  <h3>Radio buttons</h3>
+  <p>Radio buttons represent a set of options where only one may be selected.</p>
+
+  <div class="sample-container">
+    <label for="radio1"><input type="radio" name="radio" id="radio1"> Radio one</label>
+    <label for="radio2"><input type="radio" name="radio" id="radio2"> Radio two</label>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="radio">
+  <h3>Checkboxes</h3>
+  <p>Checkboxes represent a set of options where multiple selections are allowed.</p>
+
+  <p>Also use a checkbox for a binary choice (such as a yes or no question) rather
+    than two radio buttons. A radio button, once activated, cannot be
+    deactivated, whereas a single checkbox behaves as a switch to let a user
+    toggle between the two states (you can uncheck a checked checkbox).</p>
+
+  <div class="sample-container">
+    <label for="check"><input type="checkbox" name="check" id="check"> Checkbox</label>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="select">
+  <h3>Select</h3>
+
+  <div class="sample-container">
+    <label for="select">Select</label>
+    <select name="select" id="select">
+      <option>Alpha</option>
+      <option>Beta</option>
+      <option>Gamma</option>
+    </select>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="fieldset">
+  <h3>Fieldset with legend</h3>
+  <p>Use <code>fieldset</code> to group related fields together. Include a
+    <code>legend</code> as a title.</p>
+
+  <div class="sample-container">
+    <fieldset>
+      <legend>Your name</legend>
+      <p>
+        <label for="name-given">Given name</label> <input type="text" id="name-given" name="givenname">
+        <label for="name-family">Family name</label> <input type="text" id="name-family" name="familyname">
+      </p>
+    </fieldset>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>

--- a/styleguide/grid/index.html
+++ b/styleguide/grid/index.html
@@ -1,1 +1,1 @@
-<h2>Feed me Malcolm, feed me!</h2>
+<h2 class="sg-page-title">Feed me Malcolm, feed me!</h2>

--- a/styleguide/headings/index.html
+++ b/styleguide/headings/index.html
@@ -1,0 +1,69 @@
+<h2 class="sg-page-title">Headings</h2>
+
+<section id="h1">
+  <div class="sample-container">
+    <h1>Level one heading</h1>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="h2">
+  <div class="sample-container">
+    <h2>Level two heading</h2>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="h3">
+  <div class="sample-container">
+    <h3>Level three heading</h3>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="h4">
+  <div class="sample-container">
+    <h4>Level four heading</h4>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="h5">
+  <div class="sample-container">
+    <h5>Level five heading</h5>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="h6">
+  <div class="sample-container">
+    <h6>Level six heading</h6>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+

--- a/styleguide/lists/index.html
+++ b/styleguide/lists/index.html
@@ -1,1 +1,0 @@
-<h2>Feed me Malcolm, feed me!</h2>

--- a/styleguide/tables-and-lists/index.html
+++ b/styleguide/tables-and-lists/index.html
@@ -1,0 +1,154 @@
+<h2 class="sg-page-title">Tables and Lists</h2>
+
+<section id="table">
+  <h3>Tables</h3>
+  <p>Tables have no base styling in Sandstone (apart from the browser defaults).
+    Use the <code>.table</code> class to display tabular data with a bit more polish.</p>
+
+  <div class="sample-container">
+    <table class="table">
+      <caption>Table caption</caption>
+      <thead>
+        <tr>
+          <td></td>
+          <th scope="col">Column</th>
+          <th scope="col">Column</th>
+          <th scope="col">Column</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Row</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">Row</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="ul">
+  <h3>Unordered lists</h3>
+  <div class="sample-container">
+    <ul>
+      <li>list item</li>
+      <li>list item
+        <ul>
+          <li>nested list</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="ol">
+  <h3>Ordered lists</h3>
+  <div class="sample-container">
+    <ol>
+      <li>list item</li>
+      <li>list item
+        <ol>
+          <li>nested list</li>
+        </ol>
+      </li>
+    </ol>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="unstyled">
+  <h3>Unstyled lists</h3>
+  <p>It’s often handy to use an ordered or unordered list in for semantic
+    markup while avoiding any default styling, either from the browser or
+    from Sandstone. Use the <code>.unstyled</code> class to override the
+    default styling. These list items have no markers or indentation.</p>
+
+  <div class="sample-container">
+    <ul class="unstyled">
+      <li>list item</li>
+      <li>list item</li>
+    </ul>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="dl">
+  <h3>Definition lists</h3>
+  <p>Terms in standard definition lists recieve the same general styling as
+    top-level headings (<code>h1</code>). This doesn’t make a lot of sense
+    and is almost always undesirable, hence why it seems alternate styles
+    for definition lists were created over time. We should fix this in Sandstone,
+    but I’m documenting it here for now.</p>
+
+  <div class="sample-container">
+    <dl>
+      <dt>Term</dt>
+      <dd>Description</dd>
+    </dl>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="dl-simple">
+  <h3>Definition lists, simple</h3>
+  <p>Simpler definition lists, with more reasonably sized terms. This should
+    probably be the base style for this element.</p>
+
+  <div class="sample-container">
+    <dl class="simple">
+      <dt>Term</dt>
+      <dd>Description</dd>
+    </dl>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>
+
+<section id="dl=faq">
+  <h3>Frequently Asked Questions</h3>
+  <p>Lists of questions and their answers are marked up as a definition list.</p>
+
+  <div class="sample-container">
+    <dl class="faq">
+      <dt>Is this a question?</dt>
+      <dd>Yes. Yes it is.</dd>
+    </dl>
+  </div>
+
+  <aside class="code-sample show">
+    <h4>HTML</h4>
+    <pre><code class="language-markup"></code></pre>
+  </aside>
+</section>

--- a/styleguide/tables/index.html
+++ b/styleguide/tables/index.html
@@ -1,1 +1,0 @@
-<h2>Feed me Malcolm, feed me!</h2>

--- a/styleguide/themes/index.html
+++ b/styleguide/themes/index.html
@@ -1,1 +1,0 @@
-<h2>Feed me Malcolm, feed me!</h2>

--- a/styleguide/typefaces/index.html
+++ b/styleguide/typefaces/index.html
@@ -1,1 +1,0 @@
-<h2>Feed me Malcolm, feed me!</h2>


### PR DESCRIPTION
Also some general style and structure tweaks. I changed a few classes with an `.sg-` prefix to sort of namespace styles for the styleguide itself that won't collide with what's coming from Sandstone.

This isn't quite as complete as I'd like it to be, but it's a decent starting point. There are plenty of patterns and components that exist on mozorg that aren't in the basic Sandstone, they just exist in the various page-specific stylesheets. So adding those pieces to the styleguide will mean adding more CSS to render them. For now these are just common HTML elements in their base Sandstone styling and next we can start cataloging some more interesting components.

With the way mozorg is structured with all the different styles for different parts of the site and lots of one-off pages, we need to look into ways of including separate bits of CSS to render components on the styleguide without just dumping everything into one massive stylesheet (which would also introduce specificity and cascade problems). We could use `<style scoped>` but it's only supported in Firefox.

Then again, all of the deviation from the theme and the number of special, one-off pages on mozorg is the very problem we're hoping to solve in the redesign with a proper system, so maybe cataloging all the existing bits would be redundant.
